### PR TITLE
Upgrade peerDependency for rxjs 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Rx = require('rx');
+var Rx = require('rxjs');
 
 function combineLatestObj(obj) {
   var sources = [];

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "combineLatest"
   ],
   "peerDependencies": {
-    "rx": "*"
+    "rxjs": "^5.0.0-beta.0"
   },
   "author": "Andre Staltz",
   "license": "MIT"


### PR DESCRIPTION
Hey, 

Thanks for publishing this lib!

I'm using rxjs 5, which uses a different package name for some reason, so I needed to update the peerDependency.

This is a breaking change, of course, but I'll leave it to you to bump the version number as you're publishing.

Let me know if you need me to do anything else!
